### PR TITLE
Feature/sync changelist

### DIFF
--- a/modgit
+++ b/modgit
@@ -117,7 +117,7 @@ if [ "$1" = "help" ] || [ -z "$1" ]; then
   exit 0
 fi
 
-REGEX_ACTION="(list|info|files|ls|clone|add|update|up|update-all|up-all|remove|rm|remove-all|rm-all|proxy)"
+REGEX_ACTION="(list|info|files|ls|clone|add|update|up|update-all|up-all|syncronize|sync|remove|rm|remove-all|rm-all|proxy)"
 
 # Accept action as first argument
 if [[ "$1" =~ $REGEX_ACTION ]]; then

--- a/modgit
+++ b/modgit
@@ -62,6 +62,7 @@ copyright.*
 changelog.*
 credit.*
 faq.*
+gitchangelist
 \.travis.*
 \.git.*
 modman
@@ -376,12 +377,31 @@ sync_changelist_files()
 
 #todo: place output of `find` into var $repofiles, and also git diff list of changed files var $changelist
 
+
+
 #  foreach(target in $changelist[delete]) delete target.
 #  then foreach(file in ...) do
 #  if file in $repofiles & $changelist[add, modify],
 #    deploy and echo to $deployed_file
 #   else
 #    echo to $deployed_file
+
+
+declare -A changelist
+#set IFS to TAB
+while IFS="	", read -r -a arrayline
+do
+	((${#arrayline[@]} >= 2)) || continue #drop empty line?
+	# array item >> [skin/frontend/example/mobile/css/styles.css]=M
+	changelist[${arrayline[1]}]=${arrayline[0]}
+done < gitchangelist
+#
+#for key in ${!changelist[@]}
+#do
+#	echo "${key} ---> ${changelist[${key}]}"
+#done
+
+
 
 
   for file in $(find . -type f -not -iwholename '*.git*' | sed 's/^\.\///'); do
@@ -559,6 +579,8 @@ update_module()
   local new_commit=$(git rev-parse HEAD)
   local count=$(git diff --shortstat "$old_commit" "$new_commit" | cut -d" " -f2)
 
+
+
   [ $DRY_RUN -eq 1 ] && git checkout --quiet "$old_commit"
 
   [ "$count" = "" ] && echo "No changes found" && return 0
@@ -569,6 +591,8 @@ update_module()
     echo "$count file(s) changed"
     return 0
   fi
+  #write out basic changelist to file > file should be included into excludes.modgit
+  git --no-pager diff --name-status "$old_commit" "$new_commit" > gitchangelist
 
   if delete_files "$module" &&
     move_files "$module";

--- a/modgit
+++ b/modgit
@@ -15,6 +15,7 @@ $(tput bold)Global Commands:$(tput sgr0)
   init                         Initialize .modgit/ folder
   ls                           List installed modules
   up-all                       Update all installed modules
+  sync-all                     Sync all installed modules
   rm-all                       Remove all installed modules
 
 Available options:
@@ -116,7 +117,7 @@ if [ "$1" = "help" ] || [ -z "$1" ]; then
   exit 0
 fi
 
-REGEX_ACTION="(list|info|files|ls|clone|add|update|up|update-all|up-all|syncronize|sync|remove|rm|remove-all|rm-all|proxy)"
+REGEX_ACTION="(list|info|files|ls|clone|add|update|up|update-all|up-all|syncronize|sync|sync-all|remove|rm|remove-all|rm-all|proxy)"
 
 # Accept action as first argument
 if [[ "$1" =~ $REGEX_ACTION ]]; then
@@ -576,7 +577,7 @@ sync_module()
     echo "$count file(s) changed"
     return 0
   fi
-  #write out basic changelist to file > file should be included into excludes.modgit
+  #write out basic changelist to file
   git --no-pager diff --name-status "$old_commit" "$new_commit" > "$gitchangelist"
 
   if sync_changelist_files "$module"
@@ -851,6 +852,23 @@ case "$ACTION" in
     if ! sync_module "$module"; then
       fault "Error syncing '$module', operation cancelled"
     fi
+    ;;
+
+  sync-all)
+    # Sync all installed modules
+    [ -n "$1" ] && fault "Too many arguments for '$ACTION' command"
+
+    require_modules
+
+    errors=0
+    for module in $(ls -1 "$MODGIT_DIR"); do
+      [ -d "$MODGIT_DIR/$module" ] || continue;
+      if ! sync_module "$module"; then
+        echo_b "-e" "Error occurred while syncing '$module'"
+        errors=$((errors+1))
+      fi
+    done
+    [ $DRY_RUN -eq 0 ] && echo_b "Synced all modules with $errors error(s)"
     ;;
 
   remove|rm)

--- a/modgit
+++ b/modgit
@@ -358,123 +358,39 @@ move_files()
   return 0
 }
 
-# Synchronizes files affected by commit history
-sync_changelist_files()
+# Deletes changelist files with value "D"
+delete_changelist_files()
 {
-  local module="$1"
-  local module_dir="$MODGIT_DIR/$module"
-  local source_dir="$module_dir/source"
-  local includes_file="$module_dir/includes.modgit"
-  local excludes_file="$module_dir/excludes.modgit"
-  local modman_file="$source_dir/modman"
-  local deployed_file="$module_dir/deployed.modgit"
+	local module="$1"
+	local module_dir="$MODGIT_DIR/$module"
+	changelist=$1
 
-  > "$deployed_file" # empty file
+	[ $DRY_RUN -eq 1 ] && echo_b "Would remove changelist files:" || echo_b "Removing changelist files:"
 
-  cd "$source_dir" || return 1
+	${!changelist[@]}
 
-  [ $DRY_RUN -eq 1 ] && echo_b "Would deploy:" || echo_b "Deploying:"
+	for file in ${!changelist[@]}; do
+		if ! [ -z "$file" ] && [ -f "$ROOT/$file" ] && [ "${changelist[${file}]}" == "D" ]; then
+			echo $file
 
-#todo: place output of `find` into var $repofiles, and also git diff list of changed files var $changelist
+			# Remove deployed file and empty dirs
+			if [ $DRY_RUN -eq 0 ]; then
+				rm "$ROOT/$file" 2>/dev/null
+				prev_dir=""
+				dir=$(dirname $file)
+				while [ "$dir" != "$prev_dir" ]; do
+					prev_dir=$dir
+					test_dir="$ROOT/$dir"
+					if ! [ "$(ls -A $test_dir)" ]; then
+						rmdir $test_dir
+					fi
+					dir=${dir%/*}
+				done
+			fi
+		fi
+	done
 
-
-
-#  foreach(target in $changelist[delete]) delete target.
-#  then foreach(file in ...) do
-#  if file in $repofiles & $changelist[add, modify],
-#    deploy and echo to $deployed_file
-#   else
-#    echo to $deployed_file
-
-
-declare -A changelist
-#set IFS to TAB
-while IFS="	", read -r -a arrayline
-do
-	((${#arrayline[@]} >= 2)) || continue #drop empty line?
-	# array item >> [skin/frontend/example/mobile/css/styles.css]=M
-	changelist[${arrayline[1]}]=${arrayline[0]}
-done < gitchangelist
-#
-#for key in ${!changelist[@]}
-#do
-#	echo "${key} ---> ${changelist[${key}]}"
-#done
-
-
-
-
-  for file in $(find . -type f -not -iwholename '*.git*' | sed 's/^\.\///'); do
-    # Copy file by default
-    copy=1
-    target="$file"
-
-    # Include filters
-    if [ -s "$includes_file" ]; then
-      copy=0
-      for filter in $(cat "$includes_file"); do
-        src=$(echo $filter | cut -d: -f1)
-        if [ -z "$src" ]; then
-          continue
-        fi
-        if [[ "$file" =~ ^$src ]]; then
-          copy=1
-          # Handle optional different target
-          real=$(echo $filter | cut -d: -f2)
-          if [ "$src" != "$real" ]; then
-            tmp_src=$(echo $src | sed 's/^[\/]*//;s/[\/]*$//')
-            tmp_src="$tmp_src/"
-            tmp_src="${tmp_src//\//\\/}"
-            tmp_real=$(echo $real | sed 's/^[\/]*//;s/[\/]*$//')
-            tmp_real="$tmp_real/"
-            tmp_real="${tmp_real//\//\\/}"
-            target=$(echo $file | sed "s/$tmp_src/$tmp_real/g")
-          fi
-          break
-        fi
-      done
-    fi
-
-    # Exclude filters
-    if [ -s "$excludes_file" ] && [ $copy -eq 1 ]; then
-      for filter in $(cat "$excludes_file"); do
-        if [[ "$file" =~ ^$filter ]]; then
-          copy=0
-          break
-        fi
-      done
-    fi
-
-    if [ $copy -eq 1 ]; then
-      # Handle modman file
-      if [ -s "$modman_file" ]; then
-        IFS=$'\n'
-        for line in $(cat "$modman_file"); do
-          if [ -z "$line" ] || [[ $line =~ ^# ]] || [[ $line =~ ^@ ]]; then
-            continue
-          fi
-          IFS=$' \t'
-          line="${line/\*/}" # remove * char
-          set -- $line       # set $1 and $2
-          if [[ "$file" =~ ^$1 ]]; then
-            # Remove trailing slashes and escape paths for sed
-            src=$(echo $1 | sed 's/^[\/]*//;s/[\/]*$//')
-            dest=$(echo $2 | sed 's/^[\/]*//;s/[\/]*$//')
-            src="${src//\//\\/}"
-            dest="${dest//\//\\/}"
-            target=$(echo $file | sed "s/$src/$dest/g")
-            deploy_file "$file" "$ROOT/$target"
-            echo "$target" >> "$deployed_file"
-          fi
-        done
-      else
-        deploy_file "$file" "$ROOT/$target"
-        echo "$target" >> "$deployed_file"
-      fi
-    fi
-  done
-
-  return 0
+	return 0
 }
 
 # Creates module dir, clones git repo and optionally stores include/exclude filters
@@ -602,6 +518,192 @@ update_module()
     return 1
   fi
 }
+
+# Syncs a modules changed files
+sync_module()
+{
+  local module="$1"
+  local module_dir="$MODGIT_DIR/$module"
+  local source_dir="$module_dir/source"
+
+  require_module_dir "$module"
+
+  echo_b "Syncing '$module' module..."
+  sleep 1
+
+  cd "$source_dir"
+
+  local old_commit=$(git rev-parse HEAD)
+
+  # If module was fetched with a specific tag
+  if [ -s "$module_dir/tag.modgit" ]; then
+    if [ -z "$TAG" ]; then
+      local repo_tag=$(cat "$module_dir/tag.modgit")
+      echo "'$module' module was fetched from tag '$repo_tag' and thus cannot be updated without -t option"
+      return 1
+    fi
+
+    if [ -z $(git tag -l "$TAG") ]; then
+      echo "Tag '$TAG' does not exist"
+      return 1
+    fi
+
+    if ! git checkout --quiet "$TAG"; then
+      echo "An error occurred while fetching tag $TAG"
+      return 1
+    fi
+
+    local old_tag=$(cat "$module_dir/tag.modgit")
+    echo "Switching from tag $old_tag to $TAG"
+
+    [ $DRY_RUN -eq 0 ] && echo "$TAG" > "$module_dir/tag.modgit"
+  else
+    # Ignoring -b option (switching branch) because not yet supported
+    [ -s "$module_dir/branch.modgit" ] && BRANCH=$(cat "$module_dir/branch.modgit")
+
+    git pull --quiet origin "$BRANCH" && git submodule --quiet update --init --recursive || return 1
+  fi
+
+  local new_commit=$(git rev-parse HEAD)
+  local count=$(git diff --shortstat "$old_commit" "$new_commit" | cut -d" " -f2)
+
+
+
+  [ $DRY_RUN -eq 1 ] && git checkout --quiet "$old_commit"
+
+  [ "$count" = "" ] && echo "No changes found" && return 0
+
+  if [ $DRY_RUN -eq 1 ]; then
+    echo_b "Would modify:"
+    git --no-pager diff --name-only "$old_commit" "$new_commit"
+    echo "$count file(s) changed"
+    return 0
+  fi
+  #write out basic changelist to file > file should be included into excludes.modgit
+  git --no-pager diff --name-status "$old_commit" "$new_commit" > gitchangelist
+
+  if sync_changelist_files "$module"
+  then
+    return 0
+  else
+    return 1
+  fi
+}
+
+# Synchronizes files affected by commit history
+sync_changelist_files()
+{
+  local module="$1"
+  local module_dir="$MODGIT_DIR/$module"
+  local source_dir="$module_dir/source"
+  local includes_file="$module_dir/includes.modgit"
+  local excludes_file="$module_dir/excludes.modgit"
+  local modman_file="$source_dir/modman"
+  local deployed_file="$module_dir/deployed.modgit"
+
+  > "$deployed_file" # empty file
+
+  cd "$source_dir" || return 1
+
+  [ $DRY_RUN -eq 1 ] && echo_b "Would deploy:" || echo_b "Deploying:"
+
+	#  foreach(target in $changelist[delete]) delete target.
+	#  then foreach(file in ...) do
+	#  if file in $repofiles & $changelist[add, modify],
+	#    deploy and echo to $deployed_file
+	#   else
+	#    echo to $deployed_file
+
+	declare -A changelist
+	#set IFS to TAB
+	while IFS=" ", read -r -a arrayline
+	do
+		((${#arrayline[@]} >= 2)) || continue #drop empty line?
+		# array item >> [skin/frontend/example/mobile/css/styles.css]=M
+		changelist[${arrayline[1]}]=${arrayline[0]}
+	done < gitchangelist
+
+	#remove deployed files from changelist with value D
+	delete_changelist_files ${changelist}
+
+
+	for file in $(find . -type f -not -iwholename '*.git*' | sed 's/^\.\///'); do
+    # Copy file by default
+    copy=1
+    target="$file"
+
+    # Include filters
+    if [ -s "$includes_file" ]; then
+      copy=0
+      for filter in $(cat "$includes_file"); do
+        src=$(echo $filter | cut -d: -f1)
+        if [ -z "$src" ]; then
+          continue
+        fi
+        if [[ "$file" =~ ^$src ]]; then
+          copy=1
+          # Handle optional different target
+          real=$(echo $filter | cut -d: -f2)
+          if [ "$src" != "$real" ]; then
+            tmp_src=$(echo $src | sed 's/^[\/]*//;s/[\/]*$//')
+            tmp_src="$tmp_src/"
+            tmp_src="${tmp_src//\//\\/}"
+            tmp_real=$(echo $real | sed 's/^[\/]*//;s/[\/]*$//')
+            tmp_real="$tmp_real/"
+            tmp_real="${tmp_real//\//\\/}"
+            target=$(echo $file | sed "s/$tmp_src/$tmp_real/g")
+          fi
+          break
+        fi
+      done
+    fi
+
+    # Exclude filters
+    if [ -s "$excludes_file" ] && [ $copy -eq 1 ]; then
+      for filter in $(cat "$excludes_file"); do
+        if [[ "$file" =~ ^$filter ]]; then
+          copy=0
+          break
+        fi
+      done
+    fi
+
+    if [ $copy -eq 1 ]; then
+      # Handle modman file
+      if [ -s "$modman_file" ]; then
+        IFS=$'\n'
+        for line in $(cat "$modman_file"); do
+          if [ -z "$line" ] || [[ $line =~ ^# ]] || [[ $line =~ ^@ ]]; then
+            continue
+          fi
+          IFS=$' \t'
+          line="${line/\*/}" # remove * char
+          set -- $line       # set $1 and $2
+          if [[ "$file" =~ ^$1 ]]; then
+            # Remove trailing slashes and escape paths for sed
+            src=$(echo $1 | sed 's/^[\/]*//;s/[\/]*$//')
+            dest=$(echo $2 | sed 's/^[\/]*//;s/[\/]*$//')
+            src="${src//\//\\/}"
+            dest="${dest//\//\\/}"
+            target=$(echo $file | sed "s/$src/$dest/g")
+            deploy_file "$file" "$ROOT/$target"
+            echo "$target" >> "$deployed_file"
+          fi
+        done
+      else
+        # only deploy if it is A added or M modified
+		if [ "${changelist[$file]+isset}" ] && [ ${changelist[$file]} == "M" ] || [ ${changelist[$file]} == "A" ]; then
+			deploy_file "$file" "$ROOT/$target"
+		fi;
+        # always output file listing
+        echo "$target" >> "$deployed_file"
+      fi
+    fi
+  done
+
+  return 0
+}
+
 
 module_info()
 {
@@ -742,6 +844,16 @@ case "$ACTION" in
       fi
     done
     [ $DRY_RUN -eq 0 ] && echo_b "Updated all modules with $errors error(s)"
+    ;;
+
+  syncronize|sync)
+    # Sync specified module
+    module="$1"; shift
+    [ -z "$module" ] && fault "No module specified"
+
+    if ! sync_module "$module"; then
+      fault "Error syncing '$module', operation cancelled"
+    fi
     ;;
 
   remove|rm)

--- a/modgit
+++ b/modgit
@@ -27,6 +27,7 @@ $(tput bold)Module Commands:$(tput sgr0)
 -----------------------------------------------------------------------------------
   add <module> <repository>    Install a module by cloning specified git repository
   up <module>                  Update specified module
+  sync <module>                Sync modules changed files only
   rm <module>                  Remove specified module
   info <module>                Show information about a specific module
   files <module>               List deployed files of specified module

--- a/modgit
+++ b/modgit
@@ -357,6 +357,106 @@ move_files()
   return 0
 }
 
+# Synchronizes files affected by commit history
+sync_changelist_files()
+{
+  local module="$1"
+  local module_dir="$MODGIT_DIR/$module"
+  local source_dir="$module_dir/source"
+  local includes_file="$module_dir/includes.modgit"
+  local excludes_file="$module_dir/excludes.modgit"
+  local modman_file="$source_dir/modman"
+  local deployed_file="$module_dir/deployed.modgit"
+
+  > "$deployed_file" # empty file
+
+  cd "$source_dir" || return 1
+
+  [ $DRY_RUN -eq 1 ] && echo_b "Would deploy:" || echo_b "Deploying:"
+
+#todo: place output of `find` into var $repofiles, and also git diff list of changed files var $changelist
+
+#  foreach(target in $changelist[delete]) delete target.
+#  then foreach(file in ...) do
+#  if file in $repofiles & $changelist[add, modify],
+#    deploy and echo to $deployed_file
+#   else
+#    echo to $deployed_file
+
+
+  for file in $(find . -type f -not -iwholename '*.git*' | sed 's/^\.\///'); do
+    # Copy file by default
+    copy=1
+    target="$file"
+
+    # Include filters
+    if [ -s "$includes_file" ]; then
+      copy=0
+      for filter in $(cat "$includes_file"); do
+        src=$(echo $filter | cut -d: -f1)
+        if [ -z "$src" ]; then
+          continue
+        fi
+        if [[ "$file" =~ ^$src ]]; then
+          copy=1
+          # Handle optional different target
+          real=$(echo $filter | cut -d: -f2)
+          if [ "$src" != "$real" ]; then
+            tmp_src=$(echo $src | sed 's/^[\/]*//;s/[\/]*$//')
+            tmp_src="$tmp_src/"
+            tmp_src="${tmp_src//\//\\/}"
+            tmp_real=$(echo $real | sed 's/^[\/]*//;s/[\/]*$//')
+            tmp_real="$tmp_real/"
+            tmp_real="${tmp_real//\//\\/}"
+            target=$(echo $file | sed "s/$tmp_src/$tmp_real/g")
+          fi
+          break
+        fi
+      done
+    fi
+
+    # Exclude filters
+    if [ -s "$excludes_file" ] && [ $copy -eq 1 ]; then
+      for filter in $(cat "$excludes_file"); do
+        if [[ "$file" =~ ^$filter ]]; then
+          copy=0
+          break
+        fi
+      done
+    fi
+
+    if [ $copy -eq 1 ]; then
+      # Handle modman file
+      if [ -s "$modman_file" ]; then
+        IFS=$'\n'
+        for line in $(cat "$modman_file"); do
+          if [ -z "$line" ] || [[ $line =~ ^# ]] || [[ $line =~ ^@ ]]; then
+            continue
+          fi
+          IFS=$' \t'
+          line="${line/\*/}" # remove * char
+          set -- $line       # set $1 and $2
+          if [[ "$file" =~ ^$1 ]]; then
+            # Remove trailing slashes and escape paths for sed
+            src=$(echo $1 | sed 's/^[\/]*//;s/[\/]*$//')
+            dest=$(echo $2 | sed 's/^[\/]*//;s/[\/]*$//')
+            src="${src//\//\\/}"
+            dest="${dest//\//\\/}"
+            target=$(echo $file | sed "s/$src/$dest/g")
+            deploy_file "$file" "$ROOT/$target"
+            echo "$target" >> "$deployed_file"
+          fi
+        done
+      else
+        deploy_file "$file" "$ROOT/$target"
+        echo "$target" >> "$deployed_file"
+      fi
+    fi
+  done
+
+  return 0
+}
+
 # Creates module dir, clones git repo and optionally stores include/exclude filters
 create_module()
 {

--- a/modgit
+++ b/modgit
@@ -63,7 +63,6 @@ copyright.*
 changelog.*
 credit.*
 faq.*
-gitchangelist
 \.travis.*
 \.git.*
 modman
@@ -364,15 +363,13 @@ delete_changelist_files()
 {
 	local module="$1"
 	local module_dir="$MODGIT_DIR/$module"
-	changelist=$1
+	changelist="$1"
 
 	[ $DRY_RUN -eq 1 ] && echo_b "Would remove changelist files:" || echo_b "Removing changelist files:"
 
-	${!changelist[@]}
-
 	for file in ${!changelist[@]}; do
-		if ! [ -z "$file" ] && [ -f "$ROOT/$file" ] && [ "${changelist[${file}]}" == "D" ]; then
-			echo $file
+		if [ -f "$ROOT/$file" ] && [ "${changelist[$file]}" == "D" ]; then
+			echo "$file"
 
 			# Remove deployed file and empty dirs
 			if [ $DRY_RUN -eq 0 ]; then
@@ -508,8 +505,6 @@ update_module()
     echo "$count file(s) changed"
     return 0
   fi
-  #write out basic changelist to file > file should be included into excludes.modgit
-  git --no-pager diff --name-status "$old_commit" "$new_commit" > gitchangelist
 
   if delete_files "$module" &&
     move_files "$module";
@@ -526,6 +521,7 @@ sync_module()
   local module="$1"
   local module_dir="$MODGIT_DIR/$module"
   local source_dir="$module_dir/source"
+  local gitchangelist="$module_dir/gitchangelist"
 
   require_module_dir "$module"
 
@@ -581,7 +577,7 @@ sync_module()
     return 0
   fi
   #write out basic changelist to file > file should be included into excludes.modgit
-  git --no-pager diff --name-status "$old_commit" "$new_commit" > gitchangelist
+  git --no-pager diff --name-status "$old_commit" "$new_commit" > "$gitchangelist"
 
   if sync_changelist_files "$module"
   then
@@ -601,6 +597,7 @@ sync_changelist_files()
   local excludes_file="$module_dir/excludes.modgit"
   local modman_file="$source_dir/modman"
   local deployed_file="$module_dir/deployed.modgit"
+  local gitchangelist="$module_dir/gitchangelist"
 
   > "$deployed_file" # empty file
 
@@ -608,25 +605,24 @@ sync_changelist_files()
 
   [ $DRY_RUN -eq 1 ] && echo_b "Would deploy:" || echo_b "Deploying:"
 
-	#  foreach(target in $changelist[delete]) delete target.
-	#  then foreach(file in ...) do
-	#  if file in $repofiles & $changelist[add, modify],
-	#    deploy and echo to $deployed_file
-	#   else
-	#    echo to $deployed_file
-
 	declare -A changelist
 	#set IFS to TAB
-	while IFS=" ", read -r -a arrayline
+	while IFS=$'\t', read -r -a arrayline
 	do
 		((${#arrayline[@]} >= 2)) || continue #drop empty line?
 		# array item >> [skin/frontend/example/mobile/css/styles.css]=M
 		changelist[${arrayline[1]}]=${arrayline[0]}
-	done < gitchangelist
+	done < "$gitchangelist"
+
+	for key in ${!changelist[@]}
+	do
+		echo "${key} -> ${changelist[${key}]}"
+	done
 
 	#remove deployed files from changelist with value D
 	delete_changelist_files ${changelist}
 
+	echo_b "Syncing files:"
 
 	for file in $(find . -type f -not -iwholename '*.git*' | sed 's/^\.\///'); do
     # Copy file by default
@@ -693,7 +689,7 @@ sync_changelist_files()
         done
       else
         # only deploy if it is A added or M modified
-		if [ "${changelist[$file]+isset}" ] && [ ${changelist[$file]} == "M" ] || [ ${changelist[$file]} == "A" ]; then
+		if [ "${changelist[$file]+isset}" ] && [ "${changelist[$file]}" == "M" ] || [ "${changelist[$file]}" == "A" ]; then
 			deploy_file "$file" "$ROOT/$target"
 		fi;
         # always output file listing


### PR DESCRIPTION
Hi jreinke,
I use your script for deploying repos as part of a hand-rolled magento deployment system. The only downside is that when updating for a small fix that only affects a few files, all files are removed and then added back.  When a repo has many thousands of files it can take a while and feels a bit heavy-handed for a minor patches.

I thought that it might be possible to generate a 'changelist' of Add, Modify and Deletes and just work with those files instead - copying files marked with "M" or "A", after removing files marked with "D".
This modification does that. Please forgive any awful bash mistakes - it is not something I know.
I've tested this modification and it seems to work well. It certainly makes things quick! Please check it out.

Thanks,
Adrian.
